### PR TITLE
Update version

### DIFF
--- a/connectandprint.py
+++ b/connectandprint.py
@@ -58,7 +58,7 @@ class ConnectAndPrintPlugin(octoprint.plugin.EventHandlerPlugin,
 
 __plugin_name__ = "Connect And Print"
 __plugin_pythoncompat__ = ">=2.7,<4"
-__plugin_version__ = "1.0.0"
+__plugin_version__ = "1.1.1"
 __plugin_description__='Automatically connect to your printer on file upload and start printing'
 __plugin_author__="Max Grallinger"
 __plugin_url__="https://github.com/Maxinger15/connectandprint"


### PR DESCRIPTION
I believe that OctoPrint's Plugin Manager displays a notification to update the plugin even though the latest release is installed due to the old version in the plugin's manifest.